### PR TITLE
update gradle-plugin to 2.2.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.0'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.6'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
         classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'


### PR DESCRIPTION
The gradle-plugin should be updated to the current version which will allow us to use the newest additions for InstantRun etc. (and stop Android Studio from complaining on each gradle-sync).